### PR TITLE
Fix export tool can't generate FP16 data type

### DIFF
--- a/tensorflow_toolkit/ssd_detector/tools/export.py
+++ b/tensorflow_toolkit/ssd_detector/tools/export.py
@@ -108,6 +108,7 @@ def main(_):
     'scale': scale,
     'mean_value': mean_value,
     'tensorflow_use_custom_operations_config': ssd_config_path,
+    'data_type':args.data_type,
   }
   execute_mo(mo_params, frozen_graph, export_dir)
 


### PR DESCRIPTION
The reason export tool can't generate FR16 that data_type didn't set to the mo_params.