### PR TITLE
Correct the validation command in README.md

### DIFF
--- a/pytorch_toolkit/nncf/examples/object_detection/README.md
+++ b/pytorch_toolkit/nncf/examples/object_detection/README.md
@@ -26,7 +26,7 @@ It may take a few epochs to get the baseline accuracy results.
 
 #### Validate your model checkpoint
 To estimate the test scores of your model checkpoint use the following command:
-`python main.py -m test --config=configs/ssd300_vgg_int8_voc.json --resume <path_to_trained_model_checkpoint>`
+`python main.py -m test --config=configs/ssd300_vgg_int8_voc.json --data <path_to_dataset> --resume <path_to_trained_model_checkpoint>`
 If you want to validate an FP32 model checkpoint, make sure the compression algorithm settings are empty in the configuration file or `pretrained=True` is set.
 
 #### Export compressed model


### PR DESCRIPTION
This pull request corrects the validation command in thepytorch_toolkit/nncf/examples/object_detection/README.md. Previously the `--data <path to dataset>` was not there which is required to validate the model.